### PR TITLE
fix handling of secondary users

### DIFF
--- a/src/com/android/mms/service/DownloadRequest.java
+++ b/src/com/android/mms/service/DownloadRequest.java
@@ -38,6 +38,7 @@ import android.telephony.SmsManager;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 
+import com.android.internal.telephony.CallingPackage;
 import com.android.mms.service.exception.MmsHttpException;
 import com.android.mms.service.metrics.MmsStats;
 
@@ -61,7 +62,7 @@ public class DownloadRequest extends MmsRequest {
     private final Uri mContentUri;
 
     public DownloadRequest(RequestManager manager, int subId, String locationUrl,
-            Uri contentUri, PendingIntent downloadedIntent, String creator,
+            Uri contentUri, PendingIntent downloadedIntent, CallingPackage creator,
             Bundle configOverrides, Context context, long messageId, MmsStats mmsStats,
             TelephonyManager telephonyManager) {
         super(manager, subId, creator, configOverrides, context, messageId, mmsStats,
@@ -168,9 +169,7 @@ public class DownloadRequest extends MmsRequest {
             values.put(Telephony.Mms.DATE, System.currentTimeMillis() / 1000L);
             values.put(Telephony.Mms.READ, 0);
             values.put(Telephony.Mms.SEEN, 0);
-            if (!TextUtils.isEmpty(mCreator)) {
-                values.put(Telephony.Mms.CREATOR, mCreator);
-            }
+            values.put(Telephony.Mms.CREATOR, mCreator.packageName());
             values.put(Telephony.Mms.SUBSCRIPTION_ID, mSubId);
             if (SqliteWrapper.update(
                     context,

--- a/src/com/android/mms/service/MmsRequest.java
+++ b/src/com/android/mms/service/MmsRequest.java
@@ -42,6 +42,7 @@ import android.util.SparseArray;
 
 import com.android.internal.annotations.GuardedBy;
 import com.android.internal.annotations.VisibleForTesting;
+import com.android.internal.telephony.CallingPackage;
 import com.android.internal.telephony.flags.Flags;
 import com.android.mms.service.exception.ApnException;
 import com.android.mms.service.exception.MmsHttpException;
@@ -86,7 +87,7 @@ public abstract class MmsRequest {
          * @param maxSize maximum number of bytes to read
          * @return read pdu (else null in case of error or too big)
          */
-        public byte[] readPduFromContentUri(final Uri contentUri, final int maxSize);
+        public byte[] readPduFromContentUri(final Uri contentUri, final int maxSize, CallingPackage caller);
 
         /**
          * Write pdu to supplied content uri
@@ -102,7 +103,7 @@ public abstract class MmsRequest {
     // The SIM id
     protected int mSubId;
     // The creator app
-    protected String mCreator;
+    protected final CallingPackage mCreator;
     // MMS config
     protected Bundle mMmsConfig;
     // Context used to get TelephonyManager.
@@ -158,7 +159,7 @@ public abstract class MmsRequest {
         }
     }
 
-    public MmsRequest(RequestManager requestManager, int subId, String creator,
+    public MmsRequest(RequestManager requestManager, int subId, CallingPackage creator,
             Bundle mmsConfig, Context context, long messageId, MmsStats mmsStats,
             TelephonyManager telephonyManager) {
         currentState = MmsRequestState.Created;


### PR DESCRIPTION
MmsService#readPduBytesFromContentUri() and SendRequest#persistIfRequired() used a wrong userId when called from a secondary user. Switch them to using userId of the original caller.

Depends on:
https://github.com/GrapheneOS/platform_frameworks_base/pull/58
https://github.com/GrapheneOS/platform_manifest/pull/57
https://github.com/GrapheneOS/script/pull/76